### PR TITLE
#24 CpButton "icon" type remove

### DIFF
--- a/src/components/commons/CpButton.stories.ts
+++ b/src/components/commons/CpButton.stories.ts
@@ -1,7 +1,5 @@
-import { Component } from "vue";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import CpButton from "./CpButton.vue";
-import IconArrowLeft from "@/components/commons/images/IconArrowLeft.vue";
 
 const meta: Meta<typeof CpButton> = {
   title: "CpButton",
@@ -40,24 +38,5 @@ export const Outlined: StoryObj<{ type: string }> = {
   }),
   args: {
     type: "outlined",
-  },
-};
-
-export const Icon: StoryObj<{
-  type: string;
-  textColor: string;
-  icon: Component;
-}> = {
-  render: (args) => ({
-    components: { CpButton },
-    setup() {
-      return { args };
-    },
-    template: '<cp-button v-bind="args">Icon</cp-button>',
-  }),
-  args: {
-    type: "icon",
-    textColor: "var(--cp-color-black)",
-    icon: IconArrowLeft,
   },
 };

--- a/src/components/commons/CpButton.vue
+++ b/src/components/commons/CpButton.vue
@@ -17,7 +17,7 @@ import { ElButton } from "element-plus";
 
 const props = withDefaults(
   defineProps<{
-    type: "outlined" | "solid" | "icon";
+    type: "outlined" | "solid";
     classArr?: string[];
     bgColor?: string;
     borderRadius?: string;
@@ -76,21 +76,6 @@ const innerStyle = computed(() => {
         "--el-button-border-color": props.bgColor,
         "--el-button-active-border-color": props.hoverColor,
         "--el-button-hover-border-color": props.hoverColor,
-      };
-    }
-    case "icon": {
-      return {
-        ...common,
-        "--el-button-text-color": props.textColor,
-        "--el-button-hover-text-color": props.textColor,
-        "--el-button-active-text-color": props.textColor,
-        "--el-button-bg-color": "transparent",
-        "--el-button-hover-bg-color": "transparent",
-        "--el-button-active-bg-color": "transparent",
-        "--el-button-border-color": "transparent",
-        "--el-button-active-border-color": "transparent",
-        "--el-button-hover-border-color": "transparent",
-        padding: "0",
       };
     }
     default: {

--- a/src/components/init/ChukaPokaSignForm.vue
+++ b/src/components/init/ChukaPokaSignForm.vue
@@ -2,7 +2,7 @@
   <div :class="['sign-container', layoutTypeClass]">
     <div class="top">
       <cp-button
-        type="icon"
+        type="solid"
         :icon="IconArrowLeft"
         width="auto"
         height="auto"


### PR DESCRIPTION
## Issues 번호 :

Closes #24 

## 변경, 추가된 코드(설명 등)

- CpButton.vue에서 `icon` 타입 삭제
- 사용중이던 뒤로가기 버튼은 임시로 `solid` 타입을 사용하도록 변경해둠(CpIconButton.vue가 추가되면 수정 예정)
-
-
-

## 코드 주의점

-
-
-
-

## 스크린샷
* 수정전
<img width="1710" alt="image" src="https://github.com/Chukapoka/client/assets/56281493/e1e40f0c-321b-40fb-8f71-e4dba43629ad">


* 수정후
<img width="1710" alt="image" src="https://github.com/Chukapoka/client/assets/56281493/8933218e-fba7-4a18-a534-082338ddad22">

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

다음은 변경 사항에 대한 간결한 릴리스 노트 예시입니다:

```
- Refactor: CpButton.stories.ts 파일에서 IconArrowLeft 컴포넌트를 사용하는 Icon 스토리를 삭제
- Refactor: CpButton.vue 파일에서 type 속성의 "icon" 옵션 제거
- Bug fix: ChukaPokaSignForm.vue 파일에서 CpButton.vue의 type 속성을 "icon"에서 "solid"로 변경
```

이 예시는 주어진 변경 사항을 "Refactor"와 "Bug fix" 카테고리로 분류하였습니다. 변경 사항에 따라 적절한 카테고리를 선택하여 릴리스 노트를 작성하십시오.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->