### PR TITLE
#34 트리 상세 페이지 코드 제안

### DIFF
--- a/src/components/tree/detail/TreeDetailContent.vue
+++ b/src/components/tree/detail/TreeDetailContent.vue
@@ -12,8 +12,8 @@
         <tree-type class="tree-icon" />
         <template v-for="(treeItem, idx) in treeItemList" :key="idx">
           <tree-item
-            class="tree-item"
-            :text="treeItem.title"
+            class="-item"
+            :text="`${treeItem.title} ${idx}`"
             :style="getTreeItemPosition(idx)"
           />
         </template>
@@ -52,11 +52,11 @@ const treeSize = computed(() => {
 const treeItemList = [
   {
     id: "treeItem1",
-    title: "재형이에게",
+    title: "재형에게",
   },
   {
     id: "treeItem2",
-    title: "현진이에게",
+    title: "현진에게",
   },
   {
     id: "treeItem3",
@@ -66,7 +66,32 @@ const treeItemList = [
     id: "treeItem4",
     title: "승연에게",
   },
+  {
+    id: "treeItem5",
+    title: "승연에게",
+  },
+  {
+    id: "treeItem6",
+    title: "승연에게",
+  },
+  {
+    id: "treeItem7",
+    title: "승연에게",
+  },
+  {
+    id: "treeItem8",
+    title: "승연에게",
+  },
+  {
+    id: "treeItem9",
+    title: "승연에게",
+  },
+  {
+    id: "treeItem10",
+    title: "승연에게",
+  },
 ];
+// const treeItemDivisionList = [2,6];
 
 watch(treeSize, () => {
   console.log(treeSize.value);
@@ -75,13 +100,23 @@ watch(treeSize, () => {
 const getTreeItemPosition = (idx: number) => {
   if (idx === 0) {
     return {
-      top: "0px",
+      top: "-30px",
       left: `${treeSize.value.width / 2 - 30}px`, // 정중앙
+    };
+  } else if (idx <= 2) {
+    return {
+      top: `${(treeSize.value.height / 4) * 1 - 80}px`,
+      left: `${(treeSize.value.width / 4) * (idx === 1 ? 0 : 2) + 45}px`, // 구역을 4개로 나누어 2번인덱스는 그 중 2번째 구역으로
+    };
+  } else if (idx <= 6) {
+    return {
+      top: `${(treeSize.value.height / 4) * 2 - 80}px`,
+      left: `${(treeSize.value.width / 4) * (idx - 3)}px`, // 4개가 일정한 간격으로
     };
   } else {
     return {
-      top: `${60 * Math.floor(idx / 4 + 1)}px`,
-      left: `${(treeSize.value.width / 4) * ((idx % 4) - 1)}px`,
+      top: `${(treeSize.value.height / 4) * 3 - 80}px`,
+      left: `${((treeSize.value.width - 60) / 3) * (idx - 7) + 45}px`, // 맨 아래 층에 3개가 정렬되도록
     };
   }
 };
@@ -125,9 +160,9 @@ const getTreeItemPosition = (idx: number) => {
 }
 
 // TODO: 추후 삭제
-.tree-detail-content,
-.info,
-.body {
-  border: solid 1px black;
-}
+// .tree-detail-content,
+// .info,
+// .body {
+//   border: solid 1px black;
+// }
 </style>

--- a/src/components/tree/detail/TreeDetailContent.vue
+++ b/src/components/tree/detail/TreeDetailContent.vue
@@ -1,8 +1,24 @@
 <template>
   <div class="tree-detail-content">
-    <tree-figure tree-number="01">
-      <tree-type />
-    </tree-figure>
+    <!-- Content Header 부분 -->
+    <div class="info">
+      <div class="text">
+        <div class="title cp-text-head-2">트리 이름 적는 곳</div>
+        <div class="date cp-text-main-4">2023.12.31</div>
+      </div>
+    </div>
+    <div class="body">
+      <div ref="treeRef" class="tree-img">
+        <tree-type class="tree-icon" />
+        <template v-for="(treeItem, idx) in treeItemList" :key="idx">
+          <tree-item
+            class="tree-item"
+            :text="treeItem.title"
+            :style="getTreeItemPosition(idx)"
+          />
+        </template>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -16,18 +32,102 @@ export default defineComponent({
 
 <script setup lang="ts">
 import TreeType from "@/components/commons/images/TreeType.vue";
-import TreeFigure from "../TreeFigure.vue";
-import { defineProps } from "vue";
+import TreeItem from "@/components/tree/TreeItem.vue";
+// import TreeFigure from "../TreeFigure.vue";
+import { computed, defineProps, ref, watch } from "vue";
 defineProps<{
   id: string;
 }>();
+
+const treeRef = ref<HTMLDivElement>();
+
+/** Tree Item의 위치 범위는 Tree Height * 0.6까지 */
+const treeSize = computed(() => {
+  return {
+    width: treeRef.value?.offsetWidth ?? 0,
+    height: treeRef.value?.offsetHeight ?? 0,
+  };
+});
+
+const treeItemList = [
+  {
+    id: "treeItem1",
+    title: "재형이에게",
+  },
+  {
+    id: "treeItem2",
+    title: "현진이에게",
+  },
+  {
+    id: "treeItem3",
+    title: "은우에게",
+  },
+  {
+    id: "treeItem4",
+    title: "승연에게",
+  },
+];
+
+watch(treeSize, () => {
+  console.log(treeSize.value);
+});
+
+const getTreeItemPosition = (idx: number) => {
+  if (idx === 0) {
+    return {
+      top: "0px",
+      left: `${treeSize.value.width / 2 - 30}px`, // 정중앙
+    };
+  } else {
+    return {
+      top: `${60 * Math.floor(idx / 4 + 1)}px`,
+      left: `${(treeSize.value.width / 4) * ((idx % 4) - 1)}px`,
+    };
+  }
+};
 </script>
 
 <style scoped lang="scss">
-.tree-detail{
-  &-content{
-    width: 100%;
-    height: 100%;
+.tree-detail-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  .info .text {
+    padding: 32px 0px 12px 16px;
+
+    .date {
+      margin-top: 12px;
+      color: #adadad;
+    }
   }
+
+  .body {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+
+    .tree-img {
+      align-self: flex-end;
+      // TODO: 이미지 자체가 bottom이 비어있음
+      margin-bottom: -4px;
+      position: relative;
+
+      .tree-icon {
+        height: 100%;
+      }
+
+      .tree-item {
+        position: absolute;
+      }
+    }
+  }
+}
+
+// TODO: 추후 삭제
+.tree-detail-content,
+.info,
+.body {
+  border: solid 1px black;
 }
 </style>

--- a/src/components/tree/detail/TreeDetailFooter.vue
+++ b/src/components/tree/detail/TreeDetailFooter.vue
@@ -34,7 +34,7 @@ defineProps<{
 }
 
 // TODO: 추후 삭제
-.tree-detail-footer {
-  border: 1px solid black;
-}
+// .tree-detail-footer {
+//   border: 1px solid black;
+// }
 </style>

--- a/src/components/tree/detail/TreeDetailFooter.vue
+++ b/src/components/tree/detail/TreeDetailFooter.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="tree-detail-content">
-    <tree-figure tree-number="01">
-      <tree-type />
-    </tree-figure>
+  <div class="tree-detail-footer">
+    <cp-button type="solid">초대하기</cp-button>
   </div>
 </template>
 
@@ -10,13 +8,15 @@
 import { defineComponent } from "vue";
 
 export default defineComponent({
-  name: "TreeDetailContent",
+  name: "TreeDetailFooter",
 });
 </script>
 
 <script setup lang="ts">
-import TreeType from "@/components/commons/images/TreeType.vue";
-import TreeFigure from "../TreeFigure.vue";
+// import TreeType from "@/components/commons/images/TreeType.vue";
+// import TreeFigure from "../TreeFigure.vue";
+import CpButton from "@/components/commons/CpButton.vue";
+
 import { defineProps } from "vue";
 defineProps<{
   id: string;
@@ -24,10 +24,17 @@ defineProps<{
 </script>
 
 <style scoped lang="scss">
-.tree-detail{
-  &-content{
-    width: 100%;
-    height: 100%;
-  }
+.tree-detail-footer {
+  height: 20%;
+  background-color: #cbe8bf;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+// TODO: 추후 삭제
+.tree-detail-footer {
+  border: 1px solid black;
 }
 </style>

--- a/src/components/tree/detail/TreeDetailHeader.vue
+++ b/src/components/tree/detail/TreeDetailHeader.vue
@@ -1,5 +1,13 @@
 <template>
-  <div>
+  <div class="tree-detail-header">
+    <cp-icon-button type="withText" text-align="end">
+      <template #icon>
+        <icon-arrow-left />
+      </template>
+      <template #text>뒤로가기</template>
+    </cp-icon-button>
+  </div>
+  <!-- <div>
     <div class="tree-detail-header">
       <div class="tree-detail-title">
         <h3 class="cp-text-head-2 tree-detail-title-h3">트리 이름 적는 곳</h3>
@@ -11,7 +19,7 @@
         <p class="cp-text-main-4">2000.12.18</p>
       </div>
     </div>
-  </div>
+  </div> -->
 </template>
 
 <script lang="ts">
@@ -24,7 +32,7 @@ export default defineComponent({
 
 <script setup lang="ts">
 import CpIconButton from "@/components/commons/CpIconButton.vue";
-import IconEditPen from "@/components/commons/images/IconEditPen.vue";
+import IconArrowLeft from "@/components/commons/images/IconArrowLeft.vue";
 import { defineProps } from "vue";
 defineProps<{
   id: string;
@@ -32,22 +40,8 @@ defineProps<{
 </script>
 
 <style scoped lang="scss">
-.tree-detail {
-  &-header {
-    padding: 1.5rem 1rem;
-    h3 {
-      margin: 0;
-    }
-  }
-  &-title {
-    display: flex;
-    &-h3 {
-      color: var(--cp-color-chocolate);
-    }
-  }
-  &-date p {
-    margin: 0.5rem 0;
-    color: var(--cp-color-gray-500);
-  }
+// TODO: 추후 삭제
+.tree-detail-header {
+  border: 1px solid black;
 }
 </style>

--- a/src/containers/tree/detail/TreeDetailContainer.vue
+++ b/src/containers/tree/detail/TreeDetailContainer.vue
@@ -1,12 +1,11 @@
 <template>
-  <div class="tree-detail-container-background">
-    <cp-layout :layout-type="LayoutType.Mobile">
-      <div class="tree-detail-container-wrap">
-        <tree-detail-header :id="id" />
-        <tree-detail-content :id="id" />
-      </div>
-    </cp-layout>
-  </div>
+  <cp-layout :layout-type="LayoutType.Mobile">
+    <div class="tree-detail-container">
+      <tree-detail-header :id="id" />
+      <tree-detail-content :id="id" />
+      <tree-detail-footer :id="id" />
+    </div>
+  </cp-layout>
 </template>
 
 <script lang="ts">
@@ -18,8 +17,9 @@ export default defineComponent({
 </script>
 
 <script setup lang="ts">
-import TreeDetailContent from "@/components/tree/detail/TreeDetailContent.vue";
 import TreeDetailHeader from "@/components/tree/detail/TreeDetailHeader.vue";
+import TreeDetailContent from "@/components/tree/detail/TreeDetailContent.vue";
+import TreeDetailFooter from "@/components/tree/detail/TreeDetailFooter.vue";
 import { defineProps } from "vue";
 import { LayoutType } from "@/composables/use-window-size-wrap";
 import CpLayout from "@/components/commons/CpLayout.vue";
@@ -31,20 +31,25 @@ defineProps<{
 
 <style scoped lang="scss">
 .tree-detail-container {
-  &-background {
-    width: 100%;
-    height: 100%;
-    background-position: center center;
-    // 사이즈 지정해야 하는데 어떻게 동적으로 할지 모루겠음. rem이니까 이대로 해도 되나..?
-    background-size: 37.5rem 42.5rem;
-    background-repeat: repeat-x;
-    background-image: url("@/components/tree/background/background_01.png");
-  }
-  &-wrap {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
+  background-color: #fefcf8;
+  height: calc(100vh - 2rem);
+
+  display: flex;
+  flex-direction: column;
+  // &-background {
+  //   width: 100%;
+  //   height: 100%;
+  //   background-position: center center;
+  //   // 사이즈 지정해야 하는데 어떻게 동적으로 할지 모루겠음. rem이니까 이대로 해도 되나..?
+  //   background-size: 37.5rem 42.5rem;
+  //   background-repeat: repeat-x;
+  //   background-image: url("@/components/tree/background/background_01.png");
+  // }
+  // &-wrap {
+  //   width: 100%;
+  //   height: 100%;
+  //   display: flex;
+  //   flex-direction: column;
+  // }
 }
 </style>


### PR DESCRIPTION
## Issues 번호 :

Closes #xx

## 변경, 추가된 코드(설명 등)
- header, content(info, body), footer로 나눔
-
-
-
-

## 코드 주의점
- 트리 아이템 배치 로직은 좀 더 고민해봐야함
- border는 컴포넌트의 구분을 나타내기 위한 임시조치 (추후 삭제 해야함)
-
-

## 스크린샷
<img width="1822" alt="스크린샷 2024-03-14 10 41 50" src="https://github.com/Chukapoka/client/assets/56281493/eae30db4-bece-408d-8b29-2a4800214474">
<img width="1822" alt="스크린샷 2024-03-14 10 41 57" src="https://github.com/Chukapoka/client/assets/56281493/76aefef1-c829-429e-8cd6-01f6adf1efc7">

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: `TreeType` 컴포넌트 추가. SVG 아이콘을 렌더링하며, `fillColor` prop을 통해 색상 설정 가능.
- New Feature: `TreeFigure` 컴포넌트 추가. `treeNumber` 프롭스를 정의하고 사용 가능한 템플릿, 스크립트, 스타일 구현.
- Refactor: Tree 상세 페이지 컴포넌트에 대한 코드 변경으로, 트리 아이템의 위치 계산 및 레이아웃 조정.
- New Feature: `TreeDetailFooter` 컴포넌트 추가. 초대하기 버튼을 포함한 footer 구현 및 스타일링.
- New Feature: `TreeDetailHeader` 컴포넌트 추가. 주석 처리된 코드 제거 및 border 속성 임시 추가.
- Refactor: `tree-detail` 컴포넌트를 `TreeDetailContainer`로 변경하고, `layoutType` prop 추가.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->